### PR TITLE
comic id support

### DIFF
--- a/R/get_comic.R
+++ b/R/get_comic.R
@@ -8,6 +8,8 @@
 #' @param tag Character string specifying the keyword tag (e.g.,
 #' \code{"birthday"}).
 #'
+#' @param comic_id Character string specifying the commic id (e.g., \code{"10228108"})
+#'
 #' @export
 #'
 #' @examples
@@ -15,9 +17,17 @@
 #' my_id <- "1551b314-5e8a-4477-aca2-088c05963111-v1"
 #' get_comic(my_id, tag = "edvard")
 #' get_comic(c(my_id, my_id), tag = "edvard")
-get_comic <- function(id, tag) {
+get_comic <- function(id, tag = NULL, comic_id = NULL) {
   friends <- length(id) > 1
-  comic_id <- get_comic_id(tag, friends = friends)
+
+  if(is.null(tag) & is.null(comic_id)){
+    stop('tag or comic_id must be specified')
+  } else if(!is.null(tag) & !is.null(comic_id)){
+    stop('specify either tag or comic_id')
+  } else if(!is.null(tag)){
+    comic_id <- get_comic_id(tag, friends = friends)
+  }
+
   base <- "https://render.bitstrips.com/v2/cpanel"  # base URL
   if (length(id) > 1) {
     if (length(id == 2)) {

--- a/R/plot_comic.R
+++ b/R/plot_comic.R
@@ -8,6 +8,8 @@
 #' @param tag Character string specifying the keyword tag (e.g.,
 #' \code{"birthday"}).
 #'
+#' @param comic_id Character string specifying the commic id (e.g., \code{"10228108"})
+#'
 #' @export
 #'
 #' @examples
@@ -17,8 +19,8 @@
 #'
 #' # Plot with friends
 #' plot_comic(c(my_id, my_id), tag = "sloth")
-plot_comic <- function(id, tag) {
-  img <- get_comic(id, tag)
+plot_comic <- function(id, tag = NULL, comic_id = NULL) {
+  img <- get_comic(id, tag, comic_id)
   # usr <- par()
   graphics::par(mar = c(0, 0, 0, 0) + 0.1)
   graphics::plot(grDevices::as.raster(img))

--- a/man/get_comic.Rd
+++ b/man/get_comic.Rd
@@ -4,7 +4,7 @@
 \alias{get_comic}
 \title{Get Bitmoji comic}
 \usage{
-get_comic(id, tag)
+get_comic(id, tag = NULL, comic_id = NULL)
 }
 \arguments{
 \item{id}{Character string specifying the users unique ID. Can also be a
@@ -12,6 +12,8 @@ vector of length 2.}
 
 \item{tag}{Character string specifying the keyword tag (e.g.,
 \code{"birthday"}).}
+
+\item{comic_id}{Character string specifying the commic id (e.g., \code{"10228108"})}
 }
 \description{
 Get a Bitmoji comic.

--- a/man/plot_comic.Rd
+++ b/man/plot_comic.Rd
@@ -4,7 +4,7 @@
 \alias{plot_comic}
 \title{Plot Bitmoji comic}
 \usage{
-plot_comic(id, tag)
+plot_comic(id, tag = NULL, comic_id = NULL)
 }
 \arguments{
 \item{id}{Character string specifying the users unique ID. Can also be a
@@ -12,6 +12,8 @@ vector of length 2.}
 
 \item{tag}{Character string specifying the keyword tag (e.g.,
 \code{"birthday"}).}
+
+\item{comic_id}{Character string specifying the commic id (e.g., \code{"10228108"})}
 }
 \description{
 Plot a Bitmoji comic.


### PR DESCRIPTION
Adds support for directly specifying a comic id rather than a tag that returns a random matching comic